### PR TITLE
Handle config file and add additional validations

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,19 @@
 module github.com/projectdiscovery/goflags
 
-go 1.14
+go 1.17
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08
 	github.com/pkg/errors v0.9.1
+	github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5
 	github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/karrick/godirwalk v1.16.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08 h1:ox2F0PSMlrAAiAdk
 github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5 h1:2dbm7UhrAKnccZttr78CAmG768sSCd+MBn4ayLVDeqA=
+github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5/go.mod h1:U+QCpQnX8o2N2w0VUGyAzjM3yBAe4BKedVElxiImsx0=
 github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe h1:tQTgf5XLBgZbkJDPtnV3SfdP9tzz5ZWeDBwv8WhnH9Q=
 github.com/projectdiscovery/stringsutil v0.0.0-20210804142656-fd3c28dbaafe/go.mod h1:oTRc18WBv9t6BpaN9XBY+QmG28PUpsyDzRht56Qf49I=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/goflags.go
+++ b/goflags.go
@@ -121,7 +121,7 @@ func (flagSet *FlagSet) Parse() error {
 	if err := flagSet.validateDefaultConfig(config); err != nil {
 		if !strings.Contains(err.Error(), EofYaml.Error()) {
 			data, _ := ioutil.ReadFile(config)
-			ioutil.WriteFile(provider, data, os.FileMode(0644))
+			_ = ioutil.WriteFile(provider, data, os.FileMode(0644))
 			_ = flagSet.writeToFile(config)
 			return errors.New(fmt.Sprintf("Existing keys/token have been migrated to %s, use -providerconfig flag to use the provider config file", provider))
 		}
@@ -147,7 +147,7 @@ func (flagSet *FlagSet) GenerateProviderConfig(data map[string]interface{}) {
 	if marshalledBytes, err := yaml.Marshal(data); err == nil {
 		homePath, _ := os.UserHomeDir()
 		provider := filepath.Join(homePath, ".config", appName, "provider.yaml")
-		ioutil.WriteFile(provider, marshalledBytes, os.ModePerm)
+		_ = ioutil.WriteFile(provider, marshalledBytes, os.ModePerm)
 	}
 }
 

--- a/goflags.go
+++ b/goflags.go
@@ -113,7 +113,7 @@ func (flagSet *FlagSet) Parse() error {
 	config := flagSet.GetDefaultConfigPath()
 	provider := flagSet.GetProviderConfigPath()
 	_ = os.MkdirAll(filepath.Dir(config), os.ModePerm)
-	if fileutil.FileExists(config) {
+	if !fileutil.FileExists(config) {
 		return flagSet.writeToFile(config)
 	}
 	if err := flagSet.validateDefaultConfig(config); err != nil {
@@ -121,7 +121,7 @@ func (flagSet *FlagSet) Parse() error {
 			data, _ := ioutil.ReadFile(config)
 			_ = ioutil.WriteFile(provider, data, os.FileMode(0644))
 			_ = flagSet.writeToFile(config)
-			return fmt.Errorf("Existing keys/token have been migrated to %s, use -providerconfig flag to use the provider config file", provider)
+			return fmt.Errorf("existing keys/token have been migrated to %s, use -providerconfig flag to use the provider config file", provider)
 		}
 	}
 	if flagSet.ProviderConfigFile {
@@ -131,7 +131,7 @@ func (flagSet *FlagSet) Parse() error {
 		if err != nil {
 			return err
 		}
-		if !fileutil.FileExists(provider) {
+		if fileutil.FileExists(provider) {
 			err = flagSet.MergeConfigFile(provider)
 		}
 		return err

--- a/goflags.go
+++ b/goflags.go
@@ -96,7 +96,7 @@ func (flagSet *FlagSet) MergeConfigFile(file string) error {
 		if !strings.Contains(err.Error(), YAML_FILE_EOF) {
 			fmt.Println(err.Error())
 			fmt.Println(REGENERATING_MSG)
-			flagSet.writeToFile(file)
+			_ = flagSet.writeToFile(file)
 		}
 		return err
 	}

--- a/goflags_test.go
+++ b/goflags_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,20 +31,21 @@ func TestGenerateDefaultConfig(t *testing.T) {
 	flagSet.StringSliceVar(&data2, "slice", []string{"item1", "item2"}, "String slice flag example value")
 	defaultConfig := string(flagSet.generateDefaultConfig())
 	parts := strings.SplitN(defaultConfig, "\n", 2)
-
 	require.Equal(t, example, parts[1], "could not get correct default config")
 	tearDown(t.Name())
 }
-
 func TestConfigFileDataTypes(t *testing.T) {
 	flagSet := NewFlagSet()
 	var data string
 	var data2 StringSlice
 	var data3 int
 	var data4 bool
+	var data5 StringSlice
 
 	flagSet.StringVar(&data, "string-value", "", "Default value for a test flag example")
 	flagSet.StringSliceVar(&data2, "slice-value", []string{}, "String slice flag example value")
+	flagSet.StringSliceVar(&data5, "severity", []string{}, "String slice flag example value")
+
 	flagSet.IntVar(&data3, "int-value", 0, "Int value example")
 	flagSet.BoolVar(&data4, "bool-value", false, "Bool value example")
 
@@ -177,8 +177,6 @@ func TestIncorrectFlagsCausePanic(t *testing.T) {
 		uniqueName := strconv.Itoa(index)
 		t.Run(uniqueName, func(t *testing.T) {
 			assert.Panics(t, func() {
-				tearDown(uniqueName)
-
 				flagSet := NewFlagSet()
 				var stringData string
 
@@ -187,6 +185,7 @@ func TestIncorrectFlagsCausePanic(t *testing.T) {
 			})
 		})
 	}
+	tearDown(t.Name())
 }
 
 type testSliceValue []interface{}
@@ -208,24 +207,19 @@ func TestCustomSliceUsageType(t *testing.T) {
 
 func TestParseStringSlice(t *testing.T) {
 	flagSet := NewFlagSet()
-
 	var stringSlice StringSlice
 	flagSet.StringSliceVarP(&stringSlice, "header", "H", []string{}, "Header values. Expected usage: -H \"header1\":\"value1\" -H \"header2\":\"value2\"")
-
 	header1 := "\"header1:value1\""
 	header2 := "\" HEADER 2: VALUE2  \""
 	header3 := "\"header3\":\"value3, value4\""
-
 	os.Args = []string{
 		"./appName",
 		"-H", header1,
 		"-header", header2,
 		"-H", header3,
 	}
-
 	err := flagSet.Parse()
 	assert.Nil(t, err)
-
 	assert.Equal(t, stringSlice, StringSlice{header1, header2, header3})
 }
 


### PR DESCRIPTION
This pr 
-Supports migration of  existing keys/token of providers to the newly created provider config file.
-Checks properties and data types mismatch.
-New flag to use custom source/provider config file, as default is created and used.