### PR TITLE
Adding FileStringSlice

### DIFF
--- a/file_normalized_string_slice.go
+++ b/file_normalized_string_slice.go
@@ -34,6 +34,22 @@ func (fileNormalizedStringSlice FileOriginalNormalizedStringSlice) String() stri
 	return ToString(fileNormalizedStringSlice)
 }
 
+type FileStringSlice []string
+
+// Set appends a value to the string slice.
+func (fileStringSlice *FileStringSlice) Set(value string) error {
+	slice, err := ToFileStringSlice(value)
+	if err != nil {
+		return err
+	}
+	*fileStringSlice = append(*fileStringSlice, slice...)
+	return nil
+}
+
+func (fileNormalizedStringSlice FileOriginalNormalizedStringSlice) String() string {
+	return ToString(fileNormalizedStringSlice)
+}
+
 var DefaultFileNormalizedStringSliceOptions = Options{
 	IsEmpty:    isEmpty,
 	Normalize:  normalizeLowercase,
@@ -52,4 +68,14 @@ var DefaultFileOriginalNormalizedStringSliceOptions = Options{
 
 func ToFileOriginalNormalizedStringSlice(value string) ([]string, error) {
 	return toStringSlice(value, DefaultFileOriginalNormalizedStringSliceOptions)
+}
+
+var DefaultFileStringSliceOptions = Options{
+	IsEmpty:    isEmpty,
+	Normalize:  normalizeTrailingParts,
+	IsFromFile: func(s string) bool { return true },
+}
+
+func ToFileStringSlice(value string) ([]string, error) {
+	return toStringSlice(value, DefaultFileStringSliceOptions)
 }

--- a/file_normalized_string_slice.go
+++ b/file_normalized_string_slice.go
@@ -46,8 +46,8 @@ func (fileStringSlice *FileStringSlice) Set(value string) error {
 	return nil
 }
 
-func (fileNormalizedStringSlice FileOriginalNormalizedStringSlice) String() string {
-	return ToString(fileNormalizedStringSlice)
+func (fileStringSlice FileStringSlice) String() string {
+	return ToString(fileStringSlice)
 }
 
 var DefaultFileNormalizedStringSliceOptions = Options{

--- a/goflags.go
+++ b/goflags.go
@@ -516,6 +516,41 @@ func (flagSet *FlagSet) FileNormalizedOriginalStringSliceVar(field *FileOriginal
 	return flagData
 }
 
+func (flagSet *FlagSet) FileStringSliceVarP(field *FileStringSlice, long, short string, defaultValue FileStringSlice, usage string) *FlagData {
+	for _, item := range defaultValue {
+		_ = field.Set(item)
+	}
+
+	flagSet.CommandLine.Var(field, short, usage)
+	flagSet.CommandLine.Var(field, long, usage)
+
+	flagData := &FlagData{
+		usage:        usage,
+		short:        short,
+		long:         long,
+		defaultValue: defaultValue,
+	}
+	flagSet.flagKeys.Set(short, flagData)
+	flagSet.flagKeys.Set(long, flagData)
+	return flagData
+}
+
+func (flagSet *FlagSet) FileStringSliceVar(field *FileStringSlice, long string, defaultValue FileStringSlice, usage string) *FlagData {
+	for _, item := range defaultValue {
+		_ = field.Set(item)
+	}
+
+	flagSet.CommandLine.Var(field, long, usage)
+
+	flagData := &FlagData{
+		usage:        usage,
+		long:         long,
+		defaultValue: defaultValue,
+	}
+	flagSet.flagKeys.Set(long, flagData)
+	return flagData
+}
+
 // StringSliceVarP adds a string slice flag with a shortname and longname
 // Supports ONE value at a time. Adding multiple values require repeating the argument (-flag value1 -flag value2)
 // No value normalization is happening.
@@ -557,7 +592,6 @@ func (flagSet *FlagSet) StringSliceVar(field *StringSlice, long string, defaultV
 	return flagData
 }
 
-
 // CommaSeparatedStringSliceVar adds a string slice flag with a longname
 // No value normalization is happening.
 func (flagSet *FlagSet) CommaSeparatedStringSliceVar(field *CommaSeparatedStringSlice, long string, defaultValue CommaSeparatedStringSlice, usage string) *FlagData {
@@ -596,7 +630,6 @@ func (flagSet *FlagSet) CommaSeparatedStringSliceVarP(field *CommaSeparatedStrin
 	flagSet.flagKeys.Set(long, flagData)
 	return flagData
 }
-
 
 // FileCommaSeparatedStringSliceVar adds a string slice flag with a longname
 // No value normalization is happening.

--- a/slice_common.go
+++ b/slice_common.go
@@ -105,6 +105,10 @@ func isEmpty(s string) bool {
 	return strings.TrimSpace(s) == ""
 }
 
+func normalizeTrailingParts(s string) string {
+	return strings.TrimSpace(s)
+}
+
 func normalize(s string) string {
 	return strings.TrimSpace(strings.Trim(strings.TrimSpace(s), string(quotes)))
 }


### PR DESCRIPTION
This PR adds the new option FileStringSlice that reads from the file as-is, removing only leading and trailing spaces