### PR TITLE
Adding norm. orig. file string slice

### DIFF
--- a/slice_common.go
+++ b/slice_common.go
@@ -109,6 +109,10 @@ func isEmpty(s string) bool {
 	return strings.TrimSpace(s) == ""
 }
 
+func isFromFile(_ string) bool {
+	return true
+}
+
 func normalizeTrailingParts(s string) string {
 	return strings.TrimSpace(s)
 }

--- a/string_slice_options.go
+++ b/string_slice_options.go
@@ -27,7 +27,7 @@ var CommaSeparatedStringSliceOptions = Options{
 // Example: -flag test.txt => {"value1", "value2"}
 var FileCommaSeparatedStringSliceOptions = Options{
 	IsEmpty:    isEmpty,
-	IsFromFile: func(s string) bool { return true },
+	IsFromFile: isFromFile,
 }
 
 // NormalizedOriginalStringSliceOptions represents a list of items
@@ -48,7 +48,7 @@ var NormalizedOriginalStringSliceOptions = Options{
 var FileNormalizedStringSliceOptions = Options{
 	IsEmpty:    isEmpty,
 	Normalize:  normalizeLowercase,
-	IsFromFile: func(s string) bool { return true },
+	IsFromFile: isFromFile,
 }
 
 // FileStringSliceOptions represents a list of items stored in a file
@@ -57,7 +57,7 @@ var FileNormalizedStringSliceOptions = Options{
 var FileStringSliceOptions = Options{
 	IsEmpty:    isEmpty,
 	Normalize:  normalizeTrailingParts,
-	IsFromFile: func(s string) bool { return true },
+	IsFromFile: isFromFile,
 }
 
 // NormalizedStringSliceOptions represents a list of items
@@ -66,4 +66,13 @@ var FileStringSliceOptions = Options{
 var NormalizedStringSliceOptions = Options{
 	IsEmpty:   isEmpty,
 	Normalize: normalizeLowercase,
+}
+
+// FileNormalizedOriginalStringSliceOptions represents a list of items stored in a file
+// Tokenization: Comma
+// Normalization: Standard
+var FileNormalizedOriginalStringSliceOptions = Options{
+	IsEmpty:    isEmpty,
+	Normalize:  normalize,
+	IsFromFile: isFromFile,
 }

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -97,3 +97,13 @@ func TestFileStringSliceOptions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"value1,value2", "value3"}, result, "could not get correct path")
 }
+
+func TestFileNormalizedOriginalStringSliceOptions(t *testing.T) {
+	result, err := ToStringSlice("/Users/Home/Test/test.yaml", FileNormalizedOriginalStringSliceOptions)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"/Users/Home/Test/test.yaml"}, result, "could not get correct path")
+
+	result, err = ToStringSlice("'Test User'", FileNormalizedOriginalStringSliceOptions)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"Test User"}, result, "could not get correct path")
+}


### PR DESCRIPTION
## Description
Adding missing `FileNormalizedOriginalStringSliceOption`
Closes #73 