### PR TITLE
StringSlice CLI should replace default values

### DIFF
--- a/enum_var_test.go
+++ b/enum_var_test.go
@@ -25,7 +25,7 @@ func TestEnumVarPositive(t *testing.T) {
 	}
 	err := flagSet.Parse()
 	assert.Nil(t, err)
-	assert.Equal(t, enumString, "type1")
+	assert.Equal(t, "type1", enumString)
 	tearDown(t.Name())
 }
 

--- a/goflags_test.go
+++ b/goflags_test.go
@@ -70,7 +70,7 @@ duration-value: 1h`
 	require.Nil(t, err, "could not merge temporary config")
 
 	require.Equal(t, "test", data, "could not get correct string")
-	require.Equal(t, StringSlice{"test", "test2"}, data2, "could not get correct string slice")
+	require.Equal(t, StringSlice{Value: []string{"test", "test2"}}, data2, "could not get correct string slice")
 	require.Equal(t, 543, data3, "could not get correct int")
 	require.Equal(t, true, data4, "could not get correct bool")
 	require.Equal(t, time.Hour, data5, "could not get correct duration")
@@ -146,7 +146,7 @@ BOOLEAN:
    -bool-with-default-value          Bool with default value example (default true)
    -bwdv, -bool-with-default-value2  Bool with default value example #2 (default true)
 `
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 
 	tearDown(t.Name())
 }
@@ -234,7 +234,7 @@ func TestParseStringSlice(t *testing.T) {
 	err := flagSet.Parse()
 	assert.Nil(t, err)
 
-	assert.Equal(t, StringSlice{header1, header2, header3}, stringSlice)
+	assert.Equal(t, StringSlice{Value: []string{header1, header2, header3}}, stringSlice)
 	tearDown(t.Name())
 
 }
@@ -258,7 +258,7 @@ func TestParseCommaSeparatedStringSlice(t *testing.T) {
 	err := flagSet.Parse()
 	assert.Nil(t, err)
 
-	assert.Equal(t, csStringSlice, StringSlice{value1, value2, value3})
+	assert.Equal(t, csStringSlice, StringSlice{Value: []string{value1, value2, value3}})
 	tearDown(t.Name())
 }
 
@@ -288,7 +288,7 @@ value3`
 	err = flagSet.Parse()
 	assert.Nil(t, err)
 
-	assert.Equal(t, csStringSlice, StringSlice{value1, value2, value3})
+	assert.Equal(t, csStringSlice, StringSlice{Value: []string{value1, value2, value3}})
 	tearDown(t.Name())
 }
 
@@ -312,7 +312,39 @@ config-only:
 	err = flagSet.MergeConfigFile("test.yaml")
 	require.Nil(t, err, "could not merge temporary config")
 
-	require.Equal(t, StringSlice{"test", "test2"}, data, "could not get correct string slice")
+	require.Equal(t, StringSlice{Value: []string{"test", "test2"}}, data, "could not get correct string slice")
+	tearDown(t.Name())
+}
+
+func TestSetDefaultStringSliceValue(t *testing.T) {
+	var data StringSlice
+	flagSet := NewFlagSet()
+	flagSet.StringSliceVar(&data, "test", []string{"A,A,A"}, "Default value for a test flag example", CommaSeparatedStringSliceOptions)
+	err := flagSet.CommandLine.Parse([]string{"-test", "item1"})
+	require.Nil(t, err)
+	require.Equal(t, StringSlice{Value: []string{"item1"}}, data, "could not get correct string slice")
+
+	var data2 StringSlice
+	flagSet2 := NewFlagSet()
+	flagSet2.StringSliceVar(&data2, "test", []string{"A"}, "Default value for a test flag example", CommaSeparatedStringSliceOptions)
+	err = flagSet2.CommandLine.Parse([]string{"-test", "item1,item2"})
+	require.Nil(t, err)
+	require.Equal(t, StringSlice{Value: []string{"item1", "item2"}}, data2, "could not get correct string slice")
+
+	var data3 StringSlice
+	flagSet3 := NewFlagSet()
+	flagSet3.StringSliceVar(&data3, "test", []string{}, "Default value for a test flag example", CommaSeparatedStringSliceOptions)
+	err = flagSet3.CommandLine.Parse([]string{"-test", "item1,item2"})
+	require.Nil(t, err)
+	require.Equal(t, StringSlice{Value: []string{"item1", "item2"}}, data3, "could not get correct string slice")
+
+	var data4 StringSlice
+	flagSet4 := NewFlagSet()
+	flagSet4.StringSliceVar(&data4, "test", nil, "Default value for a test flag example", CommaSeparatedStringSliceOptions)
+	err = flagSet4.CommandLine.Parse([]string{"-test", "item1,\"item2\""})
+	require.Nil(t, err)
+	require.Equal(t, StringSlice{Value: []string{"item1", "item2"}}, data4, "could not get correct string slice")
+
 	tearDown(t.Name())
 }
 

--- a/port.go
+++ b/port.go
@@ -10,7 +10,8 @@ import (
 
 // Port is a list of unique ports in a normalized format
 type Port struct {
-	kv map[int]struct{}
+	kv      map[int]struct{}
+	Default bool
 }
 
 func (port Port) String() string {
@@ -28,6 +29,10 @@ func (port Port) String() string {
 
 // Set inserts a value to the port map. A number of formats are accepted.
 func (port *Port) Set(value string) error {
+	if port.Default {
+		port.kv = map[int]struct{}{}
+		port.Default = false
+	}
 	if port.kv == nil {
 		port.kv = make(map[int]struct{})
 	}

--- a/port_test.go
+++ b/port_test.go
@@ -1,6 +1,7 @@
 package goflags
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,4 +60,32 @@ func TestPortType(t *testing.T) {
 		_ = port.Set("TCP:443,UDP:53")
 		require.ElementsMatch(t, port.AsPorts(), []int{443, 53}, "could not get correct ports")
 	})
+}
+
+func TestSetDefaultPortValue(t *testing.T) {
+	var data Port
+	flagSet := NewFlagSet()
+	flagSet.PortVarP(&data, "port", "p", []string{"1,3"}, "Default value for a test flag example")
+	err := flagSet.CommandLine.Parse([]string{"-p", "11"})
+	require.Nil(t, err)
+	fmt.Println(data)
+	require.Equal(t, Port{kv: map[int]struct{}{11: {}}}, data, "could not get correct string slice")
+
+	var data2 Port
+	flagSet2 := NewFlagSet()
+	flagSet2.PortVarP(&data2, "port", "p", []string{"1,3"}, "Default value for a test flag example")
+	err = flagSet2.CommandLine.Parse([]string{"-p", "11,12"})
+	require.Nil(t, err)
+	fmt.Println(data2)
+	require.Equal(t, Port{kv: map[int]struct{}{11: {}, 12: {}}}, data2, "could not get correct string slice")
+
+	var data3 Port
+	flagSet3 := NewFlagSet()
+	flagSet3.PortVarP(&data3, "port", "p", nil, "Default value for a test flag example")
+	err = flagSet3.CommandLine.Parse([]string{"-p", "11,12"})
+	fmt.Println(data2)
+	require.Nil(t, err)
+	require.Equal(t, Port{kv: map[int]struct{}{11: {}, 12: {}}}, data3, "could not get correct string slice")
+
+	tearDown(t.Name())
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -7,10 +7,17 @@ func init() {
 }
 
 // StringSlice is a slice of strings
-type StringSlice []string
+type StringSlice struct {
+	Value   []string
+	Default bool
+}
 
 // Set appends a value to the string slice.
 func (stringSlice *StringSlice) Set(value string) error {
+	if stringSlice.Default {
+		stringSlice.Value = []string{}
+		stringSlice.Default = false
+	}
 	option, ok := optionMap[stringSlice]
 	if !ok {
 		option = StringSliceOptions
@@ -19,10 +26,10 @@ func (stringSlice *StringSlice) Set(value string) error {
 	if err != nil {
 		return err
 	}
-	*stringSlice = append(*stringSlice, values...)
+	stringSlice.Value = append(stringSlice.Value, values...)
 	return nil
 }
 
 func (stringSlice StringSlice) String() string {
-	return ToString(stringSlice)
+	return ToString(stringSlice.Value)
 }

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -48,7 +48,7 @@ func TestNormalizedStringSlicePositive(t *testing.T) {
 		result, err := ToStringSlice(value, NormalizedStringSliceOptions)
 		fmt.Println(result)
 		assert.Nil(t, err)
-		assert.Equal(t, result, expected)
+		assert.Equal(t, expected, result)
 	}
 }
 


### PR DESCRIPTION
- [x] Fix #95
- [x] Add tests for #95
- [x] Fix Default Port Input (Same as #95)
- [x] Add tests for Default Port Input
- [x] Minor changes (expected and value in tests reversed)

I can confirm `PortVarP()` is affected as well:
```Go
[...]
func main() {
	testOptions := &Options{}
	flagSet := goflags.NewFlagSet()
	flagSet.CreateGroup("info", "Info",
		flagSet.PortVarP(&testOptions.Port, "port", "p", []string{"1"}, "port test"),
	)
	if err := flagSet.Parse(); err != nil {
		log.Fatal(err)
	}
	fmt.Println(testOptions.Port)
}
```

```bash
go run port-flag.go -p 2
(1,2)
```

Honestly I don't like this solution, it breaks the concept of having the StringSlice exactly equal as []string (And so reflect.Type).  
That said, personal considerations:

- This solution is backward-compatible (in my opinion the most desired property).

- `(flagSet *FlagSet) Parse()` calls `flagSet.CommandLine.Parse(os.Args[1:])` (ref: https://github.com/projectdiscovery/goflags/blob/main/goflags.go#L96) and it's not possible to override the second method. In that method the way used to set a flag value is to call `Set()` and (as far as I know) there is no way to distinguish between user-inputted values and default ones. So there is no way to override the default value out of using the `Set()` method.

- Each input flag should have the notion of default value, that's why I've thought to change StringSlice to a struct holding the Default indicator.

- Maybe another solution could be also to change `optionMap` to be accessible from outside (`OptionMap`) and insert the boolean value in that struct.


TBH I don't have a clear abstract view of the code. I'm open to discuss, get suggestions and change completely the solution.

This PR closes #95.