### PR TITLE
Add case sensitive support to flagset

### DIFF
--- a/goflags.go
+++ b/goflags.go
@@ -563,16 +563,14 @@ func (flagSet *FlagSet) getGroupbyName(name string) groupData {
 func (flagSet *FlagSet) getFlagByName(name string) *FlagData {
 	var flagData *FlagData
 	flagSet.flagKeys.forEach(func(key string, data *FlagData) {
-		if flagSet.CaseSensitive {
-			if data.long == name || data.short == name {
-				flagData = data
-				return
-			}
-		} else {
-			if strings.EqualFold(data.long, name) || strings.EqualFold(data.short, name) {
-				flagData = data
-				return
-			}
+		// check if the items are equal
+		// - Case sensitive
+		equal := flagSet.CaseSensitive && (data.long == name || data.short == name)
+		// - Case insensitive
+		equalFold := !flagSet.CaseSensitive && (strings.EqualFold(data.long, name) || strings.EqualFold(data.short, name))
+		if equal || equalFold {
+			flagData = data
+			return
 		}
 	})
 	return flagData

--- a/goflags.go
+++ b/goflags.go
@@ -22,6 +22,7 @@ import (
 
 // FlagSet is a list of flags for an application
 type FlagSet struct {
+	CaseSensitive  bool
 	Marshal        bool
 	description    string
 	flagKeys       InsertionOrderedMap
@@ -536,7 +537,7 @@ func (flagSet *FlagSet) usageFunc() {
 			flagSet.displayGroupUsageFunc(newUniqueDeduper(), group, cliOutput, writer)
 			return
 		}
-		flag := flagSet.getFlagByName(strings.ToLower(os.Args[2]))
+		flag := flagSet.getFlagByName(os.Args[2])
 		if flag != nil {
 			flagSet.displaySingleFlagUsageFunc(os.Args[2], flag, cliOutput, writer)
 			return
@@ -562,9 +563,16 @@ func (flagSet *FlagSet) getGroupbyName(name string) groupData {
 func (flagSet *FlagSet) getFlagByName(name string) *FlagData {
 	var flagData *FlagData
 	flagSet.flagKeys.forEach(func(key string, data *FlagData) {
-		if strings.EqualFold(data.long, name) || strings.EqualFold(data.short, name) {
-			flagData = data
-			return
+		if flagSet.CaseSensitive {
+			if data.long == name || data.short == name {
+				flagData = data
+				return
+			}
+		} else {
+			if strings.EqualFold(data.long, name) || strings.EqualFold(data.short, name) {
+				flagData = data
+				return
+			}
 		}
 	})
 	return flagData

--- a/goflags_test.go
+++ b/goflags_test.go
@@ -365,6 +365,44 @@ func TestSetDefaultStringSliceValue(t *testing.T) {
 	tearDown(t.Name())
 }
 
+func TestCaseSensitiveFlagSet(t *testing.T) {
+	flagSet := NewFlagSet()
+	flagSet.CaseSensitive = true
+	var verbose, keyVal bool
+	flagSet.CreateGroup("Test", "Test",
+		flagSet.BoolVarP(&verbose, "verbose", "v", false, "show verbose output"),
+		flagSet.BoolVarP(&keyVal, "var", "V", false, "custom vars in key=value format"),
+	)
+	output := &bytes.Buffer{}
+	flagSet.CommandLine.SetOutput(output)
+
+	os.Args = []string{
+		os.Args[0],
+		"-h",
+		"V",
+	}
+	flagSet.usageFunc()
+
+	resultOutput := output.String()
+	actual := resultOutput[strings.Index(resultOutput, "Flags:\n"):]
+	expected := "Flags:\n   -V, -var  custom vars in key=value format\n"
+	assert.Equal(t, expected, actual)
+
+	output = &bytes.Buffer{}
+	flagSet.CommandLine.SetOutput(output)
+	os.Args = []string{
+		os.Args[0],
+		"-h",
+		"v",
+	}
+	flagSet.usageFunc()
+
+	resultOutput = output.String()
+	actual = resultOutput[strings.Index(resultOutput, "Flags:\n"):]
+	expected = "Flags:\n   -v, -verbose  show verbose output\n"
+	assert.Equal(t, expected, actual)
+}
+
 func tearDown(uniqueValue string) {
 	flag.CommandLine = flag.NewFlagSet(uniqueValue, flag.ContinueOnError)
 	flag.CommandLine.Usage = flag.Usage


### PR DESCRIPTION
can't differentiate `./binary -h v` and `./binary -h V`