### PR TITLE
Custom Help Text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# IDE Settings
+/.idea
+/.vscode
+/.vs

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -36,6 +36,7 @@ func main() {
 		flagSet.SizeVarP(&testOptions.fileSize, "max-size", "ms", "", "max file size"),
 		flagSet.DurationVar(&testOptions.duration, "timeout", time.Hour, "timeout"),
 	)
+	flagSet.SetCustomHelpText("EXAMPLE USAGE:\ngo run ./examples/basic [OPTIONS]")
 
 	if err := flagSet.Parse(); err != nil {
 		log.Fatal(err)

--- a/goflags.go
+++ b/goflags.go
@@ -528,7 +528,7 @@ func (flagSet *FlagSet) usageFunc() {
 	}
 
 	// If there is a custom help text specified, print it
-	if isNotBlank(flagSet.customHelpText) {
+	if !isEmpty(flagSet.customHelpText) {
 		fmt.Fprintf(cliOutput, "\n%s\n", flagSet.customHelpText)
 	}
 }
@@ -651,10 +651,6 @@ func (u *uniqueDeduper) isUnique(data *FlagData) bool {
 	return true
 }
 
-func isNotBlank(value string) bool {
-	return len(strings.TrimSpace(value)) != 0
-}
-
 func createUsageString(data *FlagData, currentFlag *flag.Flag) string {
 	valueType := reflect.TypeOf(currentFlag.Value)
 
@@ -713,7 +709,7 @@ func createUsageFlagNames(data *FlagData) string {
 
 	var validFlags []string
 	addValidParam := func(value string) {
-		if isNotBlank(value) {
+		if !isEmpty(value) {
 			validFlags = append(validFlags, fmt.Sprintf("-%s", value))
 		}
 	}

--- a/goflags.go
+++ b/goflags.go
@@ -25,6 +25,7 @@ type FlagSet struct {
 	CaseSensitive  bool
 	Marshal        bool
 	description    string
+	customHelpText string
 	flagKeys       InsertionOrderedMap
 	groups         []groupData
 	CommandLine    *flag.FlagSet
@@ -80,6 +81,11 @@ func (flagData *FlagData) Hash() string {
 // SetDescription sets the description field for a flagSet to a value.
 func (flagSet *FlagSet) SetDescription(description string) {
 	flagSet.description = description
+}
+
+// SetCustomHelpText sets the help text for a flagSet to a value. This variable appends text to the default help text.
+func (flagSet *FlagSet) SetCustomHelpText(helpText string) {
+	flagSet.customHelpText = helpText
 }
 
 // SetGroup sets a group with name and description for the command line options
@@ -501,8 +507,7 @@ func (flagSet *FlagSet) usageFunc() {
 
 	writer := tabwriter.NewWriter(cliOutput, 0, 0, 1, ' ', 0)
 
-	// If user has specified group with help and we have groups, return
-	// with it's usage function
+	// If a user has specified a group with help, and we have groups, return with the tool's usage function
 	if len(flagSet.groups) > 0 && len(os.Args) == 3 {
 		group := flagSet.getGroupbyName(strings.ToLower(os.Args[2]))
 		if group.name != "" {
@@ -520,6 +525,11 @@ func (flagSet *FlagSet) usageFunc() {
 		flagSet.usageFuncForGroups(cliOutput, writer)
 	} else {
 		flagSet.usageFuncInternal(writer)
+	}
+
+	// If there is a custom help text specified, print it
+	if isNotBlank(flagSet.customHelpText) {
+		fmt.Fprintf(cliOutput, "\n%s\n", flagSet.customHelpText)
 	}
 }
 


### PR DESCRIPTION
Allow users of the library to add custom text to the end of the "help" block. This allows support for contact information, example usage, and other notes.

An example usage was added in [`examples/basic/main.go`](./examples/basic/main.go)