### PR TITLE
add flag support act as flag with defaultValue or option with value

### DIFF
--- a/dynamic_var.go
+++ b/dynamic_var.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 type dynamicFlag struct {
@@ -54,6 +55,13 @@ func (df *dynamicFlag) Set(value string) error {
 			return nil
 		}
 		*stringField = value
+	case reflect.Slice:
+		sliceField := df.field.(*[]string)
+		if isBoolValue {
+			*sliceField = df.defaultValue.([]string)
+			return nil
+		}
+		*sliceField = append(*sliceField, strings.Split(value, ",")...)
 	default:
 		return errors.New("unsupported type")
 	}
@@ -70,8 +78,10 @@ func (df *dynamicFlag) String() string {
 
 // DynamicVar acts as flag with a default value or a option with value
 // example:
-//   var titleSize int
-//   flagSet.DynamicVar(&titleSize, "title", 50, "first N characters of the title")
+//
+//	var titleSize int
+//	flagSet.DynamicVar(&titleSize, "title", 50, "first N characters of the title")
+//
 // > go run ./examples/basic -title or go run ./examples/basic -title=100
 // In case of `go run ./examples/basic -title` it will use default value 50
 func (flagSet *FlagSet) DynamicVar(field interface{}, long string, defaultValue interface{}, usage string) *FlagData {

--- a/dynamic_var.go
+++ b/dynamic_var.go
@@ -1,0 +1,114 @@
+package goflags
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+type dynamicFlag struct {
+	field        interface{}
+	defaultValue interface{}
+	name         string
+}
+
+func (df *dynamicFlag) Set(value string) error {
+	fieldKind := reflect.TypeOf(df.field).Elem().Kind()
+	var isBoolValue bool
+	if _, err := strconv.ParseBool(value); err == nil {
+		isBoolValue = true
+	}
+	if fieldKind == reflect.Bool && isBoolValue {
+		boolField := df.field.(*bool)
+		*boolField = true
+		return nil
+	}
+	switch fieldKind {
+	case reflect.Int:
+		intField := df.field.(*int)
+		if isBoolValue {
+			*intField = df.defaultValue.(int)
+			return nil
+		}
+		newValue, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		*intField = newValue
+	case reflect.Float64:
+		floatField := df.field.(*float64)
+		if isBoolValue {
+			*floatField = df.defaultValue.(float64)
+			return nil
+		}
+		newValue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		*floatField = newValue
+	case reflect.String:
+		stringField := df.field.(*string)
+		if isBoolValue {
+			*stringField = df.defaultValue.(string)
+			return nil
+		}
+		*stringField = value
+	default:
+		return errors.New("unsupported type")
+	}
+	return nil
+}
+
+func (df *dynamicFlag) IsBoolFlag() bool {
+	return true
+}
+
+func (df *dynamicFlag) String() string {
+	return df.name
+}
+
+// DynamicVar acts as flag with a default value or a option with value
+// example:
+//   var titleSize int
+//   flagSet.DynamicVar(&titleSize, "title", 50, "first N characters of the title")
+// > go run ./examples/basic -title or go run ./examples/basic -title=100
+// In case of `go run ./examples/basic -title` it will use default value 50
+func (flagSet *FlagSet) DynamicVar(field interface{}, long string, defaultValue interface{}, usage string) *FlagData {
+	return flagSet.DynamicVarP(field, long, "", defaultValue, usage)
+}
+
+// DynamicVarP same as DynamicVar but with short name
+func (flagSet *FlagSet) DynamicVarP(field interface{}, long, short string, defaultValue interface{}, usage string) *FlagData {
+	// validate field and defaultValue
+	if reflect.TypeOf(field).Kind() != reflect.Ptr {
+		panic(fmt.Errorf("-%v flag field must be a pointer", long))
+	}
+	if reflect.TypeOf(field).Elem().Kind() != reflect.TypeOf(defaultValue).Kind() {
+		panic(fmt.Errorf("-%v flag field and defaultValue mismatch: fied type is %v and defaultValue Type is %T", long, reflect.TypeOf(field).Elem().Kind(), defaultValue))
+	}
+	if field == nil {
+		panic(fmt.Errorf("field cannot be nil for flag -%v", long))
+	}
+
+	var dynamicFlag dynamicFlag
+	dynamicFlag.field = field
+	dynamicFlag.name = long
+	if defaultValue != nil {
+		dynamicFlag.defaultValue = defaultValue
+	}
+
+	flagData := &FlagData{
+		usage:        usage,
+		long:         long,
+		defaultValue: defaultValue,
+	}
+	if short != "" {
+		flagData.short = short
+		flagSet.CommandLine.Var(&dynamicFlag, short, usage)
+		flagSet.flagKeys.Set(short, flagData)
+	}
+	flagSet.CommandLine.Var(&dynamicFlag, long, usage)
+	flagSet.flagKeys.Set(long, flagData)
+	return flagData
+}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -17,6 +17,9 @@ type Options struct {
 	duration time.Duration
 	rls      goflags.RateLimitMap
 	severity []string
+	// Dynamic
+	titleSize int
+	target    string
 }
 
 func main() {
@@ -40,11 +43,19 @@ func main() {
 		flagSet.DurationVar(&testOptions.duration, "timeout", time.Hour, "timeout"),
 		flagSet.EnumSliceVarP(&testOptions.severity, "severity", "s", []goflags.EnumVariable{2}, "severity of the scan", goflags.AllowdTypes{"low": goflags.EnumVariable(0), "medium": goflags.EnumVariable(1), "high": goflags.EnumVariable(2)}),
 	)
+	flagSet.CreateGroup("Dynmaic", "Dynamic",
+		flagSet.DynamicVarP(&testOptions.titleSize, "title", "t", 50, "first N characters of the title"),
+		flagSet.DynamicVarP(&testOptions.target, "target", "u", "https://example.com", "target url"),
+	)
 	flagSet.SetCustomHelpText("EXAMPLE USAGE:\ngo run ./examples/basic [OPTIONS]")
 
 	if err := flagSet.Parse(); err != nil {
 		log.Fatal(err)
 	}
+
+	// TODO: remove this
+	fmt.Println("title size:", testOptions.titleSize)
+	fmt.Println("target:", testOptions.target)
 
 	// ratelimits value is
 	if len(testOptions.rls.AsMap()) > 0 {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -55,11 +55,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// TODO: remove this
-	fmt.Println("title size:", testOptions.titleSize)
-	fmt.Println("target:", testOptions.target)
-	fmt.Println("hashes:", testOptions.hashes)
-
 	// ratelimits value is
 	if len(testOptions.rls.AsMap()) > 0 {
 		fmt.Printf("Got RateLimits: %+v\n", testOptions.rls)
@@ -68,4 +63,9 @@ func main() {
 	if len(testOptions.severity) > 0 {
 		fmt.Printf("Got Severity: %+v\n", testOptions.severity)
 	}
+
+	fmt.Println("Dynamic Values Output")
+	fmt.Println("title size:", testOptions.titleSize)
+	fmt.Println("target:", testOptions.target)
+	fmt.Println("hashes:", testOptions.hashes)
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -20,6 +20,7 @@ type Options struct {
 	// Dynamic
 	titleSize int
 	target    string
+	hashes    []string
 }
 
 func main() {
@@ -46,6 +47,7 @@ func main() {
 	flagSet.CreateGroup("Dynmaic", "Dynamic",
 		flagSet.DynamicVarP(&testOptions.titleSize, "title", "t", 50, "first N characters of the title"),
 		flagSet.DynamicVarP(&testOptions.target, "target", "u", "https://example.com", "target url"),
+		flagSet.DynamicVarP(&testOptions.hashes, "hashes", "hs", []string{"md5", "sha1"}, "supported hashes"),
 	)
 	flagSet.SetCustomHelpText("EXAMPLE USAGE:\ngo run ./examples/basic [OPTIONS]")
 
@@ -56,6 +58,7 @@ func main() {
 	// TODO: remove this
 	fmt.Println("title size:", testOptions.titleSize)
 	fmt.Println("target:", testOptions.target)
+	fmt.Println("hashes:", testOptions.hashes)
 
 	// ratelimits value is
 	if len(testOptions.rls.AsMap()) > 0 {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/goflags
 
-go 1.18
+go 1.20
 
 require (
 	github.com/cnf/structhash v0.0.0-20201127153200-e1b16c1ebc08


### PR DESCRIPTION
## test

### case 1: Flag with default value
```console
✗ go run examples/basic/main.go -title -target
title size: 50
target: https://example.com
Got Severity: [high]
```
### case 2: Act as option with value
```console
✗ go run examples/basic/main.go -title=100 -target=evil.com
title size: 100
target: evil.com
Got Severity: [high]
```

### case 3: no flag/option mention
```console
go run examples/basic/main.go                            
title size: 0
target: 
Got Severity: [high]
```