### PR TITLE
run test on win and osx

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,12 +11,17 @@ on:
 jobs:  
   build:
     name: Test Builds
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version: ${{ matrix.go-version }}
 
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
### Proposal
Tests run only on linux, the GitHub actions should be extended to:
- [x] osx-latest
- [x] windows

Some tests with unix-like hardcoded paths should be either refactored or run based on conditional-build

The builds are passing: https://github.com/projectdiscovery/goflags/actions/runs/5866775646